### PR TITLE
Added option to use ChromaDB instead of Milvus.

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -20,10 +20,11 @@ AWS_DEFAULT_REGION='us-east-1'
 
 JUPYTER_BASE_URL=''
 
-# When working from notebook.
-# MILVUS_SERVER_URI='http://localhost:19530'
-# When working from docker-compose + fastAPI.
-MILVUS_SERVER_URI='http://milvus-standalone:19530'
+# Vector DB
+MILVUS_SERVER_URI='http://milvus-standalone:19530'  # Milvus DB
+# CHROMA_DB_URI='http://<username>:<password>@chromadb:8000'  # Chroma DB
+# CHROMA_SERVER_AUTHN_PROVIDER='chromadb.auth.basic_authn.BasicAuthenticationServerProvider'
+# CHROMA_SERVER_AUTHN_CREDENTIALS='<username>:<password-bcrypt-hash>'
 
 # Optional - for tracking in LangSmith
 # LANGCHAIN_TRACING_V2="true"

--- a/app/databases/vector/__init__.py
+++ b/app/databases/vector/__init__.py
@@ -1,0 +1,3 @@
+from app.databases.vector.chroma import Chroma
+
+VectorDB = Chroma

--- a/app/databases/vector/base.py
+++ b/app/databases/vector/base.py
@@ -1,0 +1,49 @@
+import abc
+import os
+
+from langchain.schema import Document
+from langchain_aws import BedrockEmbeddings
+from langchain_core.embeddings import Embeddings
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+
+class BaseVectorDatabase(abc.ABC):
+    """Base class for vector databases."""
+
+    def get_embedding_function(self) -> Embeddings:
+        """Get the embedding function for the vector database."""
+
+        # TODO: Add more options such as `Voyage`, `Gemini`.
+        return BedrockEmbeddings(
+            model_id=os.environ.get('EMBEDDING_MODEL', 'amazon.titan-embed-text-v2:0'),
+            region_name='us-east-1',
+        )
+    
+    async def split_and_store_text(
+        self,
+        text: str,
+        metadata: dict,
+        chunk_size: int = 1_000,
+        chunk_overlap: int = 200,
+    ) -> list[int]:
+        """Store the embeddings for the given text in the vector database."""
+
+        # Split the text into chunks.
+        docs = [Document(page_content=text, metadata=metadata)]
+        text_splitter = RecursiveCharacterTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+        splits = text_splitter.split_documents(docs)
+
+        # Store the embeddings for each chunk.
+        return self.add_documents(documents=splits)
+    
+    @abc.abstractmethod
+    async def delete_embeddings(self, source_id: str) -> dict:
+        """Delete the embeddings for the given text from the vector database.
+        
+        :param source_id: The `source_id` metadata parameter to delete.
+            This is not the same as the ID in the vector database, but rather the ID
+            we use to identify the source, that the chunk of text came from.
+
+        :return: A dictionary with the results of the deletion.
+        """
+        pass

--- a/app/databases/vector/chroma.py
+++ b/app/databases/vector/chroma.py
@@ -1,0 +1,86 @@
+import chromadb
+import os
+
+from langchain_chroma import Chroma as LangChroma
+from urllib.parse import urlparse
+
+from app.databases.vector.base import BaseVectorDatabase
+
+
+class Chroma(LangChroma, BaseVectorDatabase):
+
+    FILE_SYSTEM_SCHEMA = 'fs://'
+    SERVER_SCHEMA = 'http://'
+    SERVER_SECURE_SCHEMA = 'https://'
+
+    def get_chroma_http_client(self, uri: str) -> chromadb.HttpClient:
+        """Parse `uri` and return an HTTP client object for the Chroma database."""
+        
+        # Parse the URI.
+        parsed_uri = urlparse(uri)
+        host = parsed_uri.hostname
+        port = parsed_uri.port
+        username = parsed_uri.username
+        password = parsed_uri.password
+    
+        # Construct and return the client object.
+        print(f'Connecting to Chroma database at {host}:{port}')
+        return chromadb.HttpClient(
+            host=host,
+            port=port,
+            settings=chromadb.config.Settings(
+                chroma_client_auth_provider='chromadb.auth.basic_authn.BasicAuthClientProvider',
+                chroma_client_auth_credentials=f'{username}:{password}',
+            ),
+        )
+    
+    def __init__(self, collection_name: str = 'MyRAGApp', **kwargs):
+        """Initialize a Chroma database client.
+        
+        The `CHROMA_DB_URI` environment variable should be set to the URI of the Chroma database.
+
+        Supported URI schemas:
+        - `http://`: Connect to a remote Chroma database.
+        - `fs://`: Connect to a local file system database.
+        """
+
+        self.collection_name = collection_name
+        self.client = None
+
+        # Parse the connection URI and set the HTTP client or local FS directory, accordingly.
+        chroma_db_uri = os.environ.get('CHROMA_DB_URI', 'http://localhost:6000')
+        if chroma_db_uri.startswith(self.SERVER_SCHEMA) or chroma_db_uri.startswith(self.SERVER_SECURE_SCHEMA):
+            # HTTP client.
+            self.client = self.get_chroma_http_client(chroma_db_uri)
+        elif chroma_db_uri.startswith(self.FILE_SYSTEM_SCHEMA):
+            # Local file system.
+            self.client = chromadb.Client(chromadb.config.Settings(
+                is_persistent=True,
+                persist_directory=chroma_db_uri[len(self.FILE_SYSTEM_SCHEMA):],
+            ))
+        else:
+            # Invalid schema.
+            raise ValueError(f'Invalid CHROMA_DB_URI Schema: {chroma_db_uri}')
+
+        kwargs['client'] = self.client
+        default_kwargs = {
+            'embedding_function': self.get_embedding_function(),
+        }
+
+        super().__init__(
+            collection_name=collection_name,
+            **(default_kwargs | kwargs),
+        )
+
+    async def delete_embeddings(self, source_id: str) -> dict:
+        """Delete the embeddings for the given text from the Chroma database."""
+        
+        # Must use the "low-level" API to delete using a condition (and not by ID).
+        collection = self.client.get_collection(self.collection_name)
+        collection.delete(where={'source_id': source_id})
+
+        # Chroma DB doesn't provide statistics on deletion.
+        return {
+            'success': True,
+            'error_count': 0,
+        }

--- a/app/databases/vector/milvus.py
+++ b/app/databases/vector/milvus.py
@@ -1,15 +1,11 @@
 import os
 
-from pathlib import Path
-
-from langchain_aws import BedrockEmbeddings
 from langchain_milvus.vectorstores import Milvus as LangMilvus
-from langchain_core.embeddings import Embeddings
-from langchain.schema import Document
-from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+from app.databases.vector.base import BaseVectorDatabase
 
 
-class Milvus(LangMilvus):
+class Milvus(LangMilvus, BaseVectorDatabase):
     """A wrapper for a Milvus database for the project."""
 
     @staticmethod
@@ -25,14 +21,6 @@ class Milvus(LangMilvus):
         }
         # return {'uri': str(Path(__file__).parent.parent.parent / 'milvus' / 'milvus_demo.db')}
     
-    def get_embedding_function(self) -> Embeddings:
-        """Get the embedding function for the Milvus database."""
-
-        return BedrockEmbeddings(
-            model_id='amazon.titan-embed-text-v2:0',  # Consider using `Voyage` or `Gemini`.
-            region_name='us-east-1',
-        )
-
     def __init__(self, collection_name: str = 'MyRAGApp', **kwargs):
         """Initialize the Milvus database for the project."""
 
@@ -40,24 +28,13 @@ class Milvus(LangMilvus):
             'embedding_function': self.get_embedding_function(),
             'connection_args': self.get_local_connection_args(),
             'consistency_level': 'Strong',
-            'auto_id': True
+            'auto_id': True,
         }
 
         super().__init__(
             collection_name=collection_name,
             **(default_kwargs | kwargs),
         )
-
-    async def split_and_store_text(self, text: str, metadata: dict, chunk_size=1000, chunk_overlap=200) -> list[int]:
-        """Store the embeddings for the given text in the Milvus database."""
-
-        # Split the text into chunks.
-        docs = [Document(page_content=text, metadata=metadata)]
-        text_splitter = RecursiveCharacterTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
-        splits = text_splitter.split_documents(docs)
-
-        # Store the embeddings for each chunk.
-        return self.add_documents(documents=splits)
 
     async def delete_embeddings(self, source_id: str, should_compact: bool = False) -> dict:
         """Delete the embeddings for the given text from the Milvus database.

--- a/app/server/embeddings.py
+++ b/app/server/embeddings.py
@@ -2,14 +2,14 @@ from datetime import datetime
 from fastapi import APIRouter, Request
 from pydantic import BaseModel
 
-from app.databases.milvus import Milvus
+from app.databases.vector import VectorDB
 
 
 embeddings_router = APIRouter()
 
 
 class StoreTextRequest(BaseModel):
-    """The request to store the embeddings for the given text in the Milvus database."""
+    """The request to store the embeddings for the given text in the vector database."""
 
     text: str
     source_name: str
@@ -18,7 +18,7 @@ class StoreTextRequest(BaseModel):
 
 
 class DeleteTextRequest(BaseModel):
-    """The request to delete the embeddings for the given text from the Milvus database."""
+    """The request to delete the embeddings for the given text from the vector database."""
     source_id: str
 
 
@@ -27,9 +27,9 @@ async def delete_text(
     request: Request,
     delete_text_request: DeleteTextRequest,
 ) -> dict:
-    """Delete the embeddings for the given text from the Milvus database."""
+    """Delete the embeddings for the given text from the vector database."""
     
-    res = await Milvus().delete_embeddings(delete_text_request.source_id)
+    res = await VectorDB().delete_embeddings(delete_text_request.source_id)
     return {
         'status': 'success' if res['error_count'] == 0 else 'error',
         'details': res,
@@ -41,9 +41,9 @@ async def store_text(
     request: Request,
     store_text_request: StoreTextRequest,
 ) -> dict:
-    """Store the embeddings for the given text in the Milvus database."""
+    """Store the embeddings for the given text in the vector database."""
     
-    ids = await Milvus().split_and_store_text(
+    ids = await VectorDB().split_and_store_text(
         store_text_request.text,
         metadata={
             'source_name': store_text_request.source_name,

--- a/app/server/llm.py
+++ b/app/server/llm.py
@@ -13,7 +13,7 @@ from langchain_aws import ChatBedrock
 from langchain_core.messages import SystemMessage
 from langchain_core.prompts.prompt import PromptTemplate
 
-from app.databases.milvus import Milvus
+from app.databases.vector import VectorDB
 from app.databases.postgres import Database
 
 
@@ -33,7 +33,7 @@ If you're not sure, state that you're not sure."""
 async def get_llm_agent():
     
     # The Retriever in the RAG model.
-    retriever = Milvus().as_retriever(search_kwargs={'k': 8})
+    retriever = VectorDB().as_retriever(search_kwargs={'k': 8})
 
     # The ChatBot LLM
     llm = ChatBedrock(

--- a/docker-compose.chromadb.yml
+++ b/docker-compose.chromadb.yml
@@ -1,0 +1,16 @@
+---
+
+volumes:
+    chroma-data:
+
+services:
+  chromadb:
+    container_name: chromadb
+    image: chromadb/chroma:0.5.13
+    volumes:
+      - chroma-data:/chroma/chroma
+    env_file:
+      - .env
+    ports:
+      - "6000:8000"
+    restart: always

--- a/docker-compose.milvus.yml
+++ b/docker-compose.milvus.yml
@@ -1,0 +1,72 @@
+---
+
+volumes:
+    milvus-data:
+    etcd-data:
+    minio-data:
+
+services:
+  # etcd - Key-Value Store for managing Milvus metadata.
+  etcd:
+    container_name: milvus-etcd
+    image: quay.io/coreos/etcd:v3.5.5
+    environment:
+      - ETCD_AUTO_COMPACTION_MODE=revision
+      - ETCD_AUTO_COMPACTION_RETENTION=1000
+      - ETCD_QUOTA_BACKEND_BYTES=4294967296
+      - ETCD_SNAPSHOT_COUNT=50000
+    volumes:
+      - etcd-data:/etcd
+    command: etcd -advertise-client-urls=http://127.0.0.1:2379 -listen-client-urls http://0.0.0.0:2379 --data-dir /etcd
+    healthcheck:
+      test: ["CMD", "etcdctl", "endpoint", "health"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+    restart: always
+
+  # MinIO - An S3 Compatible Object Storage for Milvus.
+  minio:
+    container_name: milvus-minio
+    image: minio/minio:RELEASE.2023-03-20T20-16-18Z
+    environment:
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin
+    ports:
+      - "9001:9001"
+      - "9000:9000"
+    volumes:
+      - minio-data:/minio_data
+    command: minio server /minio_data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+    restart: always
+
+  # Milvus DB - Vector Similarity Search
+  milvus:
+    container_name: milvus-standalone
+    image: milvusdb/milvus:v2.4.6
+    command: ["milvus", "run", "standalone"]
+    security_opt:
+      - seccomp:unconfined  # TODO: Check if really needed.
+    environment:
+      ETCD_ENDPOINTS: etcd:2379
+      MINIO_ADDRESS: minio:9000
+    volumes:
+      - milvus-data:/var/lib/milvus
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9091/healthz"]
+      interval: 30s
+      start_period: 90s
+      timeout: 20s
+      retries: 3
+    ports:
+      - "19530:19530"
+      - "9091:9091"
+    depends_on:
+      - "etcd"
+      - "minio"
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,78 +1,9 @@
 ---
 
 volumes:
-    milvus-data:
-    etcd-data:
-    minio-data:
-    psql-data:
+  psql-data:
 
 services:
-
-  # etcd - Key-Value Store for managing Milvus metadata.
-  etcd:
-    container_name: milvus-etcd
-    image: quay.io/coreos/etcd:v3.5.5
-    environment:
-      - ETCD_AUTO_COMPACTION_MODE=revision
-      - ETCD_AUTO_COMPACTION_RETENTION=1000
-      - ETCD_QUOTA_BACKEND_BYTES=4294967296
-      - ETCD_SNAPSHOT_COUNT=50000
-    volumes:
-      - etcd-data:/etcd
-    command: etcd -advertise-client-urls=http://127.0.0.1:2379 -listen-client-urls http://0.0.0.0:2379 --data-dir /etcd
-    healthcheck:
-      test: ["CMD", "etcdctl", "endpoint", "health"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
-    restart: always
-
-  # MinIO - An S3 Compatible Object Storage for Milvus.
-  minio:
-    container_name: milvus-minio
-    image: minio/minio:RELEASE.2023-03-20T20-16-18Z
-    environment:
-      MINIO_ACCESS_KEY: minioadmin
-      MINIO_SECRET_KEY: minioadmin
-    ports:
-      - "9001:9001"
-      - "9000:9000"
-    volumes:
-      - minio-data:/minio_data
-    command: minio server /minio_data --console-address ":9001"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
-    restart: always
-
-  # Milvus DB - Vector Similarity Search
-  milvus:
-    container_name: milvus-standalone
-    image: milvusdb/milvus:v2.4.6
-    command: ["milvus", "run", "standalone"]
-    security_opt:
-      - seccomp:unconfined  # TODO: Check if really needed.
-    environment:
-      ETCD_ENDPOINTS: etcd:2379
-      MINIO_ADDRESS: minio:9000
-    volumes:
-      - milvus-data:/var/lib/milvus
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9091/healthz"]
-      interval: 30s
-      start_period: 90s
-      timeout: 20s
-      retries: 3
-    ports:
-      - "19530:19530"
-      - "9091:9091"
-    depends_on:
-      - "etcd"
-      - "minio"
-    restart: always
-  
   # Jupyter Lab - Prototyping
   jupyter:
     env_file:

--- a/notebooks/search-chat-bot.ipynb
+++ b/notebooks/search-chat-bot.ipynb
@@ -47,9 +47,9 @@
     "# Connect to the vector DB as a retriever.\n",
     "# This is the place to define the search algorithm, parameters and how many values (`k`) to return per query.\n",
     "\n",
-    "from app.databases.milvus import Milvus\n",
+    "from app.databases.vector import VectorDB\n",
     "\n",
-    "vector_db = Milvus()\n",
+    "vector_db = VectorDB()\n",
     "retriever = vector_db.as_retriever(search_kwargs={'k': 8})"
    ]
   },

--- a/notebooks/vector-db-setup.ipynb
+++ b/notebooks/vector-db-setup.ipynb
@@ -45,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from app.databases.milvus import Milvus\n",
+    "from app.databases.vector.milvus import Milvus\n",
     "\n",
     "vector_db = Milvus(\n",
     "    # auto_id=True,\n",

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -3,11 +3,14 @@ langchain==0.2.14
 langchain-aws==0.1.17
 langchain_community==0.2.12
 langchain-core==0.2.35
-langchain-milvus==0.1.4
 langchain-text-splitters==0.2.2
 langgraph==0.2.14
 langgraph-checkpoint-postgres==1.0.3
 langgraph-checkpoint-sqlite==1.0.0
+
+# Vector DB. Technically, you need only one of these, depending on which DB you choose to use.
+langchain-chroma==0.1.4
+langchain-milvus==0.1.4
 
 # Fix bug, see: https://github.com/pypa/setuptools/issues/4508
 # https://github.com/pypa/setuptools/issues/4476#issuecomment-2236430489


### PR DESCRIPTION
# Added option to use ChromaDB instead of Milvus.

The idea is to provide alternatives for switching the vector DB with a different vector DB, as needed. The default vector DB is still Milvus, but if needed, the user can relatively easily switch to ChromaDB.

### Details

* Created a new base class VectorDB that serves as a base interface for all future supported vector DBs.
* Added template ENV for ChromaDB.
* Added a `VectorDB` class that points to the correct implementation of `BaseVectorDatabase` currently in use in the system. This serves as the SSoT for which Vector DB is used in the system.
* Split `Milvus` out of the base `docker-compose` into its own `docker-compose` file and added a `ChromaDB` `docker-compose` file. This allows for easier instantiation of only the relevant containers.

### TODO 

* Update `README.md` with the new updated `docker compose up` command and add instructions on how to switch vector DBs.